### PR TITLE
Add a shortcut for toggling the maximed status

### DIFF
--- a/application.js
+++ b/application.js
@@ -121,7 +121,7 @@ const Application = GObject.registerClass(
             this.update_theme();
 
             this.setup_shortcut('shortcut-window-hide', 'win.hide');
-            this.setup_shortcut('shortcut-toggle-maximize', 'win.toggle-maximize')
+            this.setup_shortcut('shortcut-toggle-maximize', 'win.toggle-maximize');
             this.setup_shortcut('shortcut-terminal-copy', 'terminal.copy');
             this.setup_shortcut('shortcut-terminal-copy-html', 'terminal.copy-html');
             this.setup_shortcut('shortcut-terminal-paste', 'terminal.paste');

--- a/application.js
+++ b/application.js
@@ -121,6 +121,7 @@ const Application = GObject.registerClass(
             this.update_theme();
 
             this.setup_shortcut('shortcut-window-hide', 'win.hide');
+            this.setup_shortcut('shortcut-toggle-maximize', 'win.toggle-maximize')
             this.setup_shortcut('shortcut-terminal-copy', 'terminal.copy');
             this.setup_shortcut('shortcut-terminal-copy-html', 'terminal.copy-html');
             this.setup_shortcut('shortcut-terminal-paste', 'terminal.paste');

--- a/appwindow.js
+++ b/appwindow.js
@@ -53,26 +53,10 @@ var AppWindow = GObject.registerClass(
             this.toggle_action = this.simple_action('toggle', this.toggle.bind(this));
             this.hide_action = this.simple_action('hide', () => this.hide());
             this.simple_action('toggle-maximize', () => {
-                // Maximize the terminal and store the current height
-                const original_height = this.settings.get_double('original-window-height');
-                let current_height = this.settings.get_double('window-height');
-                let target_value = 1.0;
-
-                if (original_height && current_height === 1.0) {
-                    // if there was an original height _and_ we are full-screen recover it and clean the setting
-                    target_value = original_height;
-                    current_height = null;
-                }
-
-                this.settings.set_double('window-height', target_value);
-                this.settings.set_double('original-window-height', current_height);
+                this.settings.set_boolean('window-maximize', !this.settings.get_boolean('window-maximize'));
             });
-            // On first run, recover the original value if any
-            const original_height = this.settings.get_double('original-window-height');
-            const current_height = this.settings.get_double('window-height');
-            if (original_height && current_height === 1.0)
-                this.settings.set_double('window-height', original_height);
-            this.settings.set_double('original-window-height', null);
+            this.settings.set_boolean('window-maximize', false);
+
 
             this.simple_action('new-tab', this.insert_page.bind(this, -1));
             this.simple_action('new-tab-front', this.insert_page.bind(this, 0));

--- a/appwindow.js
+++ b/appwindow.js
@@ -53,12 +53,27 @@ var AppWindow = GObject.registerClass(
             this.toggle_action = this.simple_action('toggle', this.toggle.bind(this));
             this.hide_action = this.simple_action('hide', () => this.hide());
             this.simple_action('toggle-maximize', () => {
+                // Maximize the terminal and store the current height
+                const original_height = this.settings.get_double("original-window-height");
+                let current_height = this.settings.get_double("window-height");
                 let target_value = 1.0;
-                // If the terminal is already maximized, recover the original value, otherwise maximize it
-                if (this.settings.get_double("window-height") == 1.0) 
-                  target_value = this.settings.get_double("original-window-height");
+
+                if (original_height && current_height == 1.0) {
+                    // if there was an original height _and_ we are full-screen recover it and clean the setting
+                    target_value = original_height;
+                    current_height = null;
+                }
+
                 this.settings.set_double("window-height", target_value);
+                this.settings.set_double("original-window-height", current_height);
             });
+            // On first run, recover the original value if any
+            const original_height = this.settings.get_double("original-window-height");
+            const current_height = this.settings.get_double("window-height");
+            if (original_height && current_height == 1.0) {
+                this.settings.set_double("window-height", original_height);
+            }
+            this.settings.set_double("original-window-height", null);
 
             this.simple_action('new-tab', this.insert_page.bind(this, -1));
             this.simple_action('new-tab-front', this.insert_page.bind(this, 0));

--- a/appwindow.js
+++ b/appwindow.js
@@ -55,7 +55,6 @@ var AppWindow = GObject.registerClass(
             this.simple_action('toggle-maximize', () => {
                 this.settings.set_boolean('window-maximize', !this.settings.get_boolean('window-maximize'));
             });
-            this.settings.set_boolean('window-maximize', false);
 
 
             this.simple_action('new-tab', this.insert_page.bind(this, -1));

--- a/appwindow.js
+++ b/appwindow.js
@@ -52,6 +52,13 @@ var AppWindow = GObject.registerClass(
 
             this.toggle_action = this.simple_action('toggle', this.toggle.bind(this));
             this.hide_action = this.simple_action('hide', () => this.hide());
+            this.simple_action('toggle-maximize', () => {
+                let target_value = 1.0;
+                // If the terminal is already maximized, recover the original value, otherwise maximize it
+                if (this.settings.get_double("window-height") == 1.0) 
+                  target_value = this.settings.get_double("original-window-height");
+                this.settings.set_double("window-height", target_value);
+            });
 
             this.simple_action('new-tab', this.insert_page.bind(this, -1));
             this.simple_action('new-tab-front', this.insert_page.bind(this, 0));

--- a/appwindow.js
+++ b/appwindow.js
@@ -56,7 +56,6 @@ var AppWindow = GObject.registerClass(
                 this.settings.set_boolean('window-maximize', !this.settings.get_boolean('window-maximize'));
             });
 
-
             this.simple_action('new-tab', this.insert_page.bind(this, -1));
             this.simple_action('new-tab-front', this.insert_page.bind(this, 0));
 

--- a/appwindow.js
+++ b/appwindow.js
@@ -54,26 +54,25 @@ var AppWindow = GObject.registerClass(
             this.hide_action = this.simple_action('hide', () => this.hide());
             this.simple_action('toggle-maximize', () => {
                 // Maximize the terminal and store the current height
-                const original_height = this.settings.get_double("original-window-height");
-                let current_height = this.settings.get_double("window-height");
+                const original_height = this.settings.get_double('original-window-height');
+                let current_height = this.settings.get_double('window-height');
                 let target_value = 1.0;
 
-                if (original_height && current_height == 1.0) {
+                if (original_height && current_height === 1.0) {
                     // if there was an original height _and_ we are full-screen recover it and clean the setting
                     target_value = original_height;
                     current_height = null;
                 }
 
-                this.settings.set_double("window-height", target_value);
-                this.settings.set_double("original-window-height", current_height);
+                this.settings.set_double('window-height', target_value);
+                this.settings.set_double('original-window-height', current_height);
             });
             // On first run, recover the original value if any
-            const original_height = this.settings.get_double("original-window-height");
-            const current_height = this.settings.get_double("window-height");
-            if (original_height && current_height == 1.0) {
-                this.settings.set_double("window-height", original_height);
-            }
-            this.settings.set_double("original-window-height", null);
+            const original_height = this.settings.get_double('original-window-height');
+            const current_height = this.settings.get_double('window-height');
+            if (original_height && current_height === 1.0)
+                this.settings.set_double('window-height', original_height);
+            this.settings.set_double('original-window-height', null);
 
             this.simple_action('new-tab', this.insert_page.bind(this, -1));
             this.simple_action('new-tab-front', this.insert_page.bind(this, 0));

--- a/extension.js
+++ b/extension.js
@@ -451,6 +451,5 @@ function disconnect_settings() {
         GObject.signal_handlers_disconnect_by_func(settings, update_window_height);
         GObject.signal_handlers_disconnect_by_func(settings, set_skip_taskbar);
         GObject.signal_handlers_disconnect_by_func(settings, set_window_maximize);
-
     }
 }

--- a/extension.js
+++ b/extension.js
@@ -111,7 +111,7 @@ function enable() {
 
     settings.connect('changed::window-above', set_window_above);
     settings.connect('changed::window-stick', set_window_stick);
-    settings.connect('changed::window-height', unset_window_maximize);
+    settings.connect('changed::window-height', disable_window_maximize_setting);
     settings.connect('changed::window-height', update_window_geometry);
     settings.connect('changed::window-skip-taskbar', set_skip_taskbar);
     settings.connect('changed::window-maximize', set_window_maximized);
@@ -381,7 +381,7 @@ function set_window_maximized() {
         current_window.unmaximize(Meta.MaximizeFlags.VERTICAL);
 }
 
-function unset_window_maximize() {
+function disable_window_maximize_setting() {
     // maximize state is always off after a height change
     settings.set_boolean('window-maximize', false);
 }
@@ -446,7 +446,7 @@ function disconnect_settings() {
     if (settings) {
         GObject.signal_handlers_disconnect_by_func(settings, set_window_above);
         GObject.signal_handlers_disconnect_by_func(settings, set_window_stick);
-        GObject.signal_handlers_disconnect_by_func(settings, unset_window_maximize);
+        GObject.signal_handlers_disconnect_by_func(settings, disable_window_maximize_setting);
         GObject.signal_handlers_disconnect_by_func(settings, update_window_geometry);
         GObject.signal_handlers_disconnect_by_func(settings, set_skip_taskbar);
         GObject.signal_handlers_disconnect_by_func(settings, set_window_maximized);

--- a/extension.js
+++ b/extension.js
@@ -227,7 +227,7 @@ function focus_window_changed() {
     if (win !== null) {
         if (current_window === win || current_window.is_ancestor_of_transient(win)) {
             if (settings.get_boolean('window-maximize'))
-              window_maximize();
+                window_maximize();
             return;
         }
     }
@@ -368,7 +368,6 @@ function window_maximize() {
     if (!current_window)
         return;
 
-    const should_maximize = settings.get_boolean('window-maximize');
     if (current_window.maximized_vertically) {
         current_window.unmaximize(Meta.MaximizeFlags.VERTICAL);
         settings.set_boolean('window-maximize', false);
@@ -376,7 +375,6 @@ function window_maximize() {
         current_window.maximize(Meta.MaximizeFlags.VERTICAL);
         settings.set_boolean('window-maximize', true);
     }
-
 }
 
 function update_window_geometry() {

--- a/extension.js
+++ b/extension.js
@@ -382,7 +382,6 @@ function set_window_maximized() {
 }
 
 function unset_window_maximize() {
-    // Wrapper around upadte_window_geometry to ensure that
     // maximize state is always off after a height change
     settings.set_boolean('window-maximize', false);
 }

--- a/extension.js
+++ b/extension.js
@@ -36,10 +36,8 @@ class ExtensionDBusInterface {
             return;
 
         Main.wm.skipNextEffect(current_window.get_compositor_private());
-        if (settings.get_boolean('window-maximize')) {
-            settings.set_boolean('window-maximize', false);
-            settings.set_double('window-height', 1.0);
-        }
+        update_window_height();
+
         current_window.unmaximize(Meta.MaximizeFlags.VERTICAL);
     }
 

--- a/extension.js
+++ b/extension.js
@@ -110,6 +110,7 @@ function enable() {
     settings.connect('changed::window-stick', set_window_stick);
     settings.connect('changed::window-height', update_window_geometry);
     settings.connect('changed::window-skip-taskbar', set_skip_taskbar);
+    settings.connect('changed::window-maximize', window_maximize);
 
     DBUS_INTERFACE.export(Gio.DBus.session, '/org/gnome/Shell/Extensions/ddterm');
 }
@@ -333,6 +334,10 @@ function unmaximize_window(win) {
     if (!win.maximized_vertically)
         return;
 
+    const maximized = settings.get_boolean('window-maximize');
+    if (maximized)
+        return;
+
     const workarea = workarea_for_window(current_window);
     const target_rect = target_rect_for_workarea(workarea);
 
@@ -354,6 +359,20 @@ function update_height_setting(win) {
     const workarea = workarea_for_window(win);
     const current_height = win.get_frame_rect().height / workarea.height;
     settings.set_double('window-height', Math.min(1.0, current_height));
+}
+
+function window_maximize() {
+    if (!current_window)
+        return;
+
+    const should_maximize = settings.get_boolean('window-maximize');
+    if (current_window.maximized_vertically && should_maximize)
+        return;
+
+    if (should_maximize)
+        current_window.maximize(Meta.MaximizeFlags.VERTICAL);
+    else
+        current_window.unmaximize(Meta.MaximizeFlags.VERTICAL);
 }
 
 function update_window_geometry() {

--- a/glade/prefs.ui
+++ b/glade/prefs.ui
@@ -332,6 +332,12 @@
         <col id="3">0</col>
       </row>
       <row>
+        <col id="0">shortcut-toggle-maximize</col>
+        <col id="1" translatable="yes">Maximize/unmaximize the Window</col>
+        <col id="2">0</col>
+        <col id="3">0</col>
+      </row>
+      <row>
         <col id="0">shortcut-terminal-copy</col>
         <col id="1" translatable="yes">Copy Selected Text</col>
         <col id="2">0</col>

--- a/glade/prefs.ui
+++ b/glade/prefs.ui
@@ -333,7 +333,7 @@
       </row>
       <row>
         <col id="0">shortcut-toggle-maximize</col>
-        <col id="1" translatable="yes">Maximize/unmaximize the Window</col>
+        <col id="1" translatable="yes">Maximize/Unmaximize the Window</col>
         <col id="2">0</col>
         <col id="3">0</col>
       </row>

--- a/prefs.js
+++ b/prefs.js
@@ -169,6 +169,7 @@ function createPrefsWidgetClass(resource_path, util) {
                 this.settings_bind('background-opacity', this.opacity_adjustment, 'value');
                 this.set_scale_value_format_percent(this.opacity_scale);
                 this.settings_bind('window-height', this.window_height_adjustment, 'value');
+                this.settings_bind('original-window-height', this.window_height_adjustment, 'value');
                 this.set_scale_value_format_percent(this.window_height_scale);
 
                 this.bind_sensitive('use-theme-colors', this.color_scheme_editor, true);

--- a/prefs.js
+++ b/prefs.js
@@ -169,7 +169,6 @@ function createPrefsWidgetClass(resource_path, util) {
                 this.settings_bind('background-opacity', this.opacity_adjustment, 'value');
                 this.set_scale_value_format_percent(this.opacity_scale);
                 this.settings_bind('window-height', this.window_height_adjustment, 'value');
-                this.settings_bind('original-window-height', this.window_height_adjustment, 'value');
                 this.set_scale_value_format_percent(this.window_height_scale);
 
                 this.bind_sensitive('use-theme-colors', this.color_scheme_editor, true);

--- a/schemas/com.github.amezin.ddterm.gschema.xml
+++ b/schemas/com.github.amezin.ddterm.gschema.xml
@@ -78,7 +78,7 @@
       <range min="0.0" max="1.0"/>
     </key>
     <key name="original-window-height" type="d">
-      <default>0.6</default>
+      <default>0.0</default>
       <range min="0.0" max="1.0"/>
     </key>
 

--- a/schemas/com.github.amezin.ddterm.gschema.xml
+++ b/schemas/com.github.amezin.ddterm.gschema.xml
@@ -77,6 +77,10 @@
       <default>0.6</default>
       <range min="0.0" max="1.0"/>
     </key>
+    <key name="original-window-height" type="d">
+      <default>0.6</default>
+      <range min="0.0" max="1.0"/>
+    </key>
 
     <key name="theme-variant" enum="com.github.amezin.ddterm.ThemeVariant">
       <default>'system'</default>
@@ -278,6 +282,9 @@
       <default><![CDATA[[]]]></default>
     </key>
     <key name="shortcut-window-hide" type="as">
+      <default><![CDATA[[]]]></default>
+    </key>
+    <key name="shortcut-toggle-maximize" type="as">
       <default><![CDATA[[]]]></default>
     </key>
     <key name="hide-window-on-esc" type="b">

--- a/schemas/com.github.amezin.ddterm.gschema.xml
+++ b/schemas/com.github.amezin.ddterm.gschema.xml
@@ -77,9 +77,8 @@
       <default>0.6</default>
       <range min="0.0" max="1.0"/>
     </key>
-    <key name="original-window-height" type="d">
-      <default>0.0</default>
-      <range min="0.0" max="1.0"/>
+    <key name="window-maximize" type="b">
+      <default>false</default>
     </key>
 
     <key name="theme-variant" enum="com.github.amezin.ddterm.ThemeVariant">


### PR DESCRIPTION
This is an attempt following the instructions in #29/#30 to add a shortcut that toggles the maximized state

#### Problem
I wanted a method to quickly make the terminal cover the full screen/go back to "half-screen". It should be persistent between F12-presses and between monitors.

#### Attempted solution
When the user presses the shortcut (let's say F11) the screen height is changed to 100% and the original height stored.
If the user presses F11 again, the original height is stored.
On first run if there was an "original height" stored it restores it (and then clean that setting).

One reason for doing it in this way (instead of using for instance `fullscreen`) is resizing after maximizing, which I like doing very much.


#### Testing
I've been using it and seems to work fine. Tested only in Gnome 40 though, but I think I'm not doing anything crazy that should break on any version? Maybe I am... 

Note: first time doing gtk-stuff so there's a bit of cargo cult programming here... let me know if I did something very wrong by gtk standards! In particular, I'm not sure whether by I'm being naughty by doing `set_double("blabla", null)`...
