### PR TITLE
Support using colors from gnome terminal 

### DIFF
--- a/glade/prefs.ui
+++ b/glade/prefs.ui
@@ -1642,7 +1642,7 @@ Following helpers are available:
           </packing>
         </child>
         <child>
-          <!-- n-columns=2 n-rows=7 -->
+          <!-- n-columns=2 n-rows=8 -->
           <object class="GtkGrid">
             <property name="visible">True</property>
             <property name="can-focus">True</property>
@@ -2312,6 +2312,19 @@ Following helpers are available:
               <packing>
                 <property name="left-attach">0</property>
                 <property name="top-attach">6</property>
+                <property name="width">2</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="copy_gnome_terminal_profile_button">
+                <property name="label" translatable="yes">Copy profile from GNOME Terminal</property>
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">True</property>
+              </object>
+              <packing>
+                <property name="left-attach">0</property>
+                <property name="top-attach">7</property>
                 <property name="width">2</property>
               </packing>
             </child>


### PR DESCRIPTION
Since a lot of Gnome Shell users use Gnome Terminal, I think it is useful to sync with the color profile of Gnome Terminal.


https://user-images.githubusercontent.com/7223991/122678837-fec15d80-d21a-11eb-9549-5d9f8ac6eb15.mp4

