### PR TITLE
Add shortcuts for height and opacity

### DIFF
--- a/application.js
+++ b/application.js
@@ -143,6 +143,10 @@ const Application = GObject.registerClass(
             this.update_theme();
 
             this.setup_shortcut('shortcut-window-hide', 'win.hide');
+            this.setup_shortcut('shortcut-window-size-inc', 'win.window-size-inc');
+            this.setup_shortcut('shortcut-window-size-dec', 'win.window-size-dec');
+            this.setup_shortcut('shortcut-background-opacity-inc', 'win.background-opacity-inc');
+            this.setup_shortcut('shortcut-background-opacity-dec', 'win.background-opacity-dec');
             this.setup_shortcut('shortcut-toggle-maximize', 'app.window-maximize');
             this.setup_shortcut('shortcut-toggle-transparent-background', 'app.transparent-background');
             this.setup_shortcut('shortcut-terminal-copy', 'terminal.copy');

--- a/appwindow.js
+++ b/appwindow.js
@@ -107,6 +107,26 @@ var AppWindow = GObject.registerClass(
             this.method_handler(this.settings, 'changed::window-position', this.update_resize_boxes);
             this.update_resize_boxes();
 
+            const HEIGHT_MOD = 0.05;
+            this.simple_action('window-size-dec', () => {
+                if (this.settings.get_boolean('window-maximize'))
+                    this.settings.set_double('window-size', 1.0 - HEIGHT_MOD);
+                else
+                    this.adjust_double_setting('window-size', -HEIGHT_MOD);
+            });
+            this.simple_action('window-size-inc', () => {
+                if (!this.settings.get_boolean('window-maximize'))
+                    this.adjust_double_setting('window-size', HEIGHT_MOD);
+            });
+
+            const OPACITY_MOD = 0.05;
+            this.simple_action('background-opacity-dec', () => {
+                this.adjust_double_setting('background-opacity', -OPACITY_MOD);
+            });
+            this.simple_action('background-opacity-inc', () => {
+                this.adjust_double_setting('background-opacity', OPACITY_MOD);
+            });
+
             this.tab_select_action = new Gio.PropertyAction({
                 name: 'switch-to-tab',
                 object: this.notebook,
@@ -178,6 +198,12 @@ var AppWindow = GObject.registerClass(
             this.signal_connect(action, 'activate', func);
             this.add_action(action);
             return action;
+        }
+
+        adjust_double_setting(name, difference, min = 0.0, max = 1.0) {
+            const current = this.settings.get_double(name);
+            const new_setting = current + difference;
+            this.settings.set_double(name, Math.min(Math.max(new_setting, min), max));
         }
 
         update_tab_bar_visibility() {

--- a/glade/prefs.ui
+++ b/glade/prefs.ui
@@ -498,6 +498,30 @@ along with ddterm GNOME Shell extension.  If not, see <http://www.gnu.org/licens
         <col id="3">0</col>
       </row>
       <row>
+        <col id="0">shortcut-window-size-inc</col>
+        <col id="1" translatable="yes">Increase Window Height</col>
+        <col id="2">0</col>
+        <col id="3">0</col>
+      </row>
+      <row>
+        <col id="0">shortcut-window-size-dec</col>
+        <col id="1" translatable="yes">Decrease Window Height</col>
+        <col id="2">0</col>
+        <col id="3">0</col>
+      </row>
+      <row>
+        <col id="0">shortcut-background-opacity-inc</col>
+        <col id="1" translatable="yes">Increase Background Opacity</col>
+        <col id="2">0</col>
+        <col id="3">0</col>
+      </row>
+      <row>
+        <col id="0">shortcut-background-opacity-dec</col>
+        <col id="1" translatable="yes">Decrease Background Opacity</col>
+        <col id="2">0</col>
+        <col id="3">0</col>
+      </row>
+      <row>
         <col id="0">shortcut-toggle-transparent-background</col>
         <col id="1" translatable="yes">Enable/Disable Background Transparency</col>
         <col id="2">0</col>

--- a/schemas/com.github.amezin.ddterm.gschema.xml
+++ b/schemas/com.github.amezin.ddterm.gschema.xml
@@ -376,6 +376,18 @@
     <key name="shortcut-window-hide" type="as">
       <default><![CDATA[[]]]></default>
     </key>
+    <key name="shortcut-window-size-inc" type="as">
+      <default><![CDATA[['<Ctrl>Down']]]></default>
+    </key>
+    <key name="shortcut-window-size-dec" type="as">
+      <default><![CDATA[['<Ctrl>Up']]]></default>
+    </key>
+    <key name="shortcut-background-opacity-inc" type="as">
+      <default><![CDATA[[]]]></default>
+    </key>
+    <key name="shortcut-background-opacity-dec" type="as">
+      <default><![CDATA[[]]]></default>
+    </key>
     <key name="shortcut-toggle-maximize" type="as">
       <default><![CDATA[['F11']]]></default>
     </key>


### PR DESCRIPTION
Default keybindings for increasing/decreasing size are take from Guake, opacity bindings are unset.

This would close #70.