### PR TITLE
Add gnome-shell 41.x compatibility

### DIFF
--- a/metadata.json.in
+++ b/metadata.json.in
@@ -6,7 +6,8 @@
   "shell-version": [
     "3.36",
     "3.38",
-    "40"
+    "40",
+    "41"
   ],
   "version": 21,
   "url": "https://github.com/amezin/gnome-shell-extension-ddterm"


### PR DESCRIPTION
Tested on a fedora 35 workstation (beta) by editing manually the
metadata file at
`~/.local/share/gnome-shell/extensions/ddterm@amezin.github.com/metadata.json`.

The extension seems to be working fine.
- the shell is showing
- the setting windows open

Handful of warnings in the logs when I trigger the shell:
```
$ journalctl -fe /usr/bin/gnome-shell
sept. 29 19:44:44 hostname gnome-shell[1941]: meta_window_set_stack_position_no_sync: assertion 'window->stack_position >= 0' failed
sept. 29 19:44:44 hostname gnome-shell[1941]: meta_window_set_stack_position_no_sync: assertion 'window->stack_position >= 0' failed

$ gnome-shell --version
GNOME Shell 41.0
```

Close #77 (if the warning is harmless).